### PR TITLE
Calculate Observer Coordinate

### DIFF
--- a/object_identification/ccor_id.py
+++ b/object_identification/ccor_id.py
@@ -22,6 +22,7 @@ from .utils.coordinate_transformations import (
     get_comet_locations,
     get_star_names,
     get_ccor_observer,
+    get_observer_subpoint,
 )
 from .utils.exceptions import CCORExitError
 
@@ -64,9 +65,6 @@ def run_alg(inputs: list[Any], generate_figures: bool = False, write_output_file
     # Get constellation data (contains names, and connecting star edges, or star catalogue IDs):
     constellations = load_constellation_data()
 
-    # Define the observer (approximate from GEO location for G19):
-    observer = get_ccor_observer(earth)
-
     # Get the vignetting function for masking out the pylon/occulter disc
     # in the object map.
     if generate_figures:
@@ -92,6 +90,14 @@ def run_alg(inputs: list[Any], generate_figures: bool = False, write_output_file
         end_time = get_input_data.end_time
         image_dims = wcs.array_shape
         logger.info(f"Identifying objects for observing time: {observation_time}")
+
+        # Define the observer (approximate from GEO location for G19 if observer_geo is not set.):
+        observer_geo = get_observer_subpoint(
+            observation_time, header["EPHVEC_X"], header["EPHVEC_Y"], header["EPHVEC_Z"]
+        )
+        logger.info(f"Observer subpoint (lon, lat): {observer_geo.lon}, {observer_geo.lat}")
+        # make locs negative since skyfield uses positive values for western hemisphere.
+        observer = get_ccor_observer(earth, -observer_geo.lat, -observer_geo.lon)
 
         # FOR STARS:
         # -----------

--- a/object_identification/utils/utils_dataclasses.py
+++ b/object_identification/utils/utils_dataclasses.py
@@ -54,3 +54,10 @@ class ObjectLocations:
     s_x: npt.NDArray[Any]
     s_y: npt.NDArray[Any]
     object_distance: npt.NDArray[Any]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ObserverLocation:
+    lon: float
+    lat: float
+    height: float


### PR DESCRIPTION
Summary:
------
Currently, the code is set up with CCOR-1 in mind. This is done by manually defining the observer (space-craft) geodetic location in the code at a longitude of 0 degrees, and latitude at -75.2. Such assumption makes this algorithm incompatible with data for other instruments which may be at a different orbital slot, or for instruments orbiting at LEO (low-earth orbit).

To account for this, a new method is defined: `get_observer_subpoint` which calculates the space-craft's geodetic position using the included ephemeris vector position in the image header. Note that the current expected ephemeris data name `EPHVEC_{X,Y,Z}` may not always be compatible with other instrument data sets. For now, this works with CCOR, but a change will be considered using a ccor map object instead. 