### PR TITLE
Update Observer Location

### DIFF
--- a/object_identification/ccor_id.py
+++ b/object_identification/ccor_id.py
@@ -138,7 +138,7 @@ def run_alg(inputs: list[Any], generate_figures: bool = False, write_output_file
         logger.info("Getting comet(s) within FOV.")
         get_comets = get_comet_locations(comets=comets, sun=sun, ts=ts, observer=observer, observation_time=t, wcs=wcs)
         get_comet = get_comets.get_comet
-        valid_pixels = get_comet.valid_pixels
+        valid_pixels = get_comets.valid_pixels
         # FILE OUTGEST:
         # -------------
         logger.info("Building data dict for file outgest.")

--- a/object_identification/ccor_id.py
+++ b/object_identification/ccor_id.py
@@ -92,9 +92,7 @@ def run_alg(inputs: list[Any], generate_figures: bool = False, write_output_file
 
         # Define the observer (approximate from GEO location for G19 if observer_geo is not set.):
         try:
-            observer_geo = get_observer_subpoint(
-                observation_time, header["EPHVEC_X"], header["EPHVEC_Y"], header["EPHVEC_Z"]
-            )
+            observer_geo = get_observer_subpoint(observation_time, ccor_map.observer_coordinate)
         except KeyError:
             logger.error(
                 "Invalid key in header for ephemeris positions. Make sure to map correct keys to function call."


### PR DESCRIPTION
Summary: 
-----
Skyfield requires the location of the observer for determining the position(s) of celestial bodies in the field-of-view (FOV) of an image. Initially, the expected location of CCOR-1 (or GOES-19) was hard-coded at -75.2 longitude and 0 latitude. However, for other instruments this will not work. Instead, this PR enables the use of a SunPy map object, and the contained observer coordinate retrieved from the world coordinate system information (WCS), is used to determine the observer subpoint relative to the Earth's surface. This makes using any image data, regardless of platform, possible so as long as these metadata are contained within the data product file(s).