### PR TITLE
Add Satellite ID Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,24 @@ The table below summarizes the objects that can currently be identified by the a
 | Satellites| :x:              |
 
 ## Running the algorithm
-To the run the algorithm:
+To the run the object identification algorithm:
 
-> python -m cli -i /path/to/ccor1-l3/data/ -f -w
+> python -m cli -f -w -i /path/to/ccor1-l3/data/ 
 
 Where: 
  * -i (--input_dir): input directory
  * -f (--gen_figures): boolean to generate figures (True if set)
  * -w (--write_outputs): boolean for generating output file containing object coordinates (True if set)
+
+To run the satellite identification algorithm:
+
+> python -m cli --search_radius 30e3 --fov_angle 11.0 -i /path/to/ccor1-l3/data/ -tle /path/to/tle/data.tle
+
+Where:
+ * --search_radius: search radius for identifying candidate satellites near the instrument/observer in units km
+ * --fov_angle: instrument's FOV in units degrees
+ * -tle: path to TLE (.tle) data file corresponding to the date for the date found in --input_dir.
+
 
  Note: the CCOR vignetting file needs to be placed in the `static_required` directory as it is not available in this repository.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Where:
 
 To run the satellite identification algorithm:
 
-> python -m cli --search_radius 30e3 --fov_angle 11.0 -i /path/to/ccor1-l3/data/ -tle /path/to/tle/data.tle
+> python -m cli --search_radius 30e3 --fov_angle 11.0 -w -i /path/to/ccor1-l3/data/ -tle /path/to/tle/data.tle
 
 Where:
  * --search_radius: search radius for identifying candidate satellites near the instrument/observer in units km

--- a/cli.py
+++ b/cli.py
@@ -40,6 +40,12 @@ if __name__ == "__main__":
             run_ccor_id(files, generate_figures, write_outputs)
         else:
             logger.info(f"Running satellite identification for: {len(files)} image frames.")
-            run_satellite_id(inputs=files, tle=tle, search_radius=search_radius, fov_angle=fov_angle)
+            run_satellite_id(
+                inputs=files,
+                tle=tle,
+                search_radius=search_radius,
+                fov_angle=fov_angle,
+                write_output_files=write_outputs,
+            )
     else:
         logger.error("Invalid path to data...exiting")

--- a/cli.py
+++ b/cli.py
@@ -4,25 +4,42 @@ import os
 import glob
 
 from object_identification.ccor_id import run_alg as run_ccor_id
+from object_identification.sat_id import run_satellite_id
 
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--input_dir", type=str, required=True)
-    parser.add_argument("-f", "--gen_figures", action="store_true")
-    parser.add_argument("-w", "--write_outputs", action="store_true")
+    parser.add_argument("-i", "--input_dir", type=str, required=True, help="Path to input data")
+    parser.add_argument("-f", "--gen_figures", action="store_true", required=False, help="Generate Figure(s)")
+    parser.add_argument(
+        "-w", "--write_outputs", action="store_true", required=False, help="Write locations to output file"
+    )
+    parser.add_argument("-tle", "--tle_input", type=str, required=False, help="Path to TLE file")
+    parser.add_argument(
+        "--search_radius", type=float, required=False, help="Search radius for satellite near the observatory"
+    )
+    parser.add_argument("--fov_angle", type=float, required=False, help="Entire instrument FOV")
 
     args = parser.parse_args()
     input_dir = args.input_dir
     generate_figures = args.gen_figures
     write_outputs = args.write_outputs
 
+    # for satellite id
+    tle = args.tle_input
+    search_radius = args.search_radius
+    fov_angle = args.fov_angle
+
     # Stack Images:
     if os.path.exists(input_dir):
         files = sorted(glob.glob(input_dir + "*.fits"))[:1]
-        logger.info(f"Running object identification for: {len(files)} image frames.")
-        # Run the alg
-        run_ccor_id(files, generate_figures, write_outputs)
+        if tle is None:
+            logger.info(f"Running object identification for: {len(files)} image frames.")
+            # Run the alg
+            run_ccor_id(files, generate_figures, write_outputs)
+        else:
+            logger.info(f"Running satellite identification for: {len(files)} image frames.")
+            run_satellite_id(inputs=files, tle=tle, search_radius=search_radius, fov_angle=fov_angle)
     else:
         logger.error("Invalid path to data...exiting")

--- a/object_identification/sat_id.py
+++ b/object_identification/sat_id.py
@@ -1,0 +1,117 @@
+import os
+import logging
+from typing import Any
+
+from skyfield.api import load
+from astropy.time import Time
+
+
+from .utils.retrieve_data import load_planetary_data
+from .utils.io import read_input
+from .sat_utils.find_satellites import get_all_positions_for_times, get_satellites_in_fov
+
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+logger = logging.getLogger(__name__)
+
+
+def remove_duplicate_sat_entries(satellite_list: list[Any]) -> list[Any]:
+    """
+    Archived TLEs generally contain duplicate entries for the same satellite ID (not all).
+    These duplicates usually define both a older and updated TLE for satellite with duplicate entries.
+    This function removes the oldest TLE for a satellite with duplicate entries to ensure we
+    only use the "latest" ephemeris data relative to date of the FITs file.
+    """
+    # Removes Duplicate Satellites:
+    sat_names = [sat.name for sat in satellite_list[:]]
+    duplicates = set()  # Create a set to store duplicate entries
+    uniq_inds = []  # get the indices to access non-duplicated valid entries
+
+    # Reverse the loop order since we want to get the last duplicated entry and not the first
+    for i, sat_id in enumerate(sat_names[::-1]):
+        if sat_id not in duplicates:
+            # Ensures we get the last entry
+            uniq_inds.append(i)
+            duplicates.add(sat_id)
+
+    # Get all valid satellites (no duplicates)
+    logger.info(f"Satellite List records retained: {len(satellite_list)}.")
+
+    # Reverse back to original order
+    valid_satellites = [satellite_list[::-1][uniq_ind] for uniq_ind in uniq_inds][::-1]
+
+    return valid_satellites
+
+
+def run_satellite_id(
+    inputs: list[Any], tle: str, search_radius: int | float = 30e3, fov_angle: int | float = 11
+) -> None:
+    """
+    Retrieve candidate satellites, and their approximate pixel locations, within
+    the FOV of the image being processed using concurrent two-line element (TLE)
+    data for the date being processed.
+
+    For this analysis, we identify all possible candidate satellites relative to:
+       - DATE-BEG: beginning of image capture
+       - DATE-AVG: average time of capture
+       - DATE-END: end of image capture
+    to try and identify satellites through the entire imaging sequence.
+
+    The search radius is used to only search for valid satellites out to <search_radius> km
+    from the position of the instrument.
+
+    The <fov_angle> is used to only capture satellites within the visible FOV of the CCOR imagery.
+    """
+    # Load the timescale
+    ts = load.timescale()
+    tlabels = ["date-beg", "date-avg", "date-end"]
+
+    # Define the earth/sun ephemeris data:
+    reference_bodies = load_planetary_data()
+    earth = reference_bodies.earth
+    sun = reference_bodies.sun
+
+    # Get the satellite ephemeris data from TLE
+    try:
+        satellite_list = list(load.tle_file(tle))
+    except Exception:
+        logger.error("Invalid TLE data provided. Exiting program.")
+    logger.info(f"Original Satellite List: {len(satellite_list)} entries")
+
+    # Remove (possible) duplicate entries in archived TLE files.
+    valid_satellites = remove_duplicate_sat_entries(satellite_list=satellite_list)
+
+    # Start satellite search
+    for f in inputs[:]:
+        # Get relevant data from the input L3 data file.
+        logger.info(f"Running object identification for file: {os.path.basename(f)}")
+        get_input_data = read_input(f, ts)
+        data = get_input_data.image_data  # noqa: F841
+        header = get_input_data.header  # noqa: F841
+        ccor_map = get_input_data.ccor_map
+
+        # Get the time(s) for which we'll search for satellites
+        obs_time = Time(header["DATE-OBS"])
+        avg_time = Time(header["DATE-AVG"])
+        end_time = Time(header["DATE-END"])
+
+        tobs = ts.from_astropy(obs_time)
+        tavg = ts.from_astropy(avg_time)
+        tend = ts.from_astropy(end_time)
+
+        astro_times = [obs_time, avg_time, end_time]
+        j_times = [tobs, tavg, tend]
+
+        # Get Sun, Earth, CCOR, and Satellite Ephemeris Position Coordinates:
+        obs_satellite_data = get_all_positions_for_times(astro_times, j_times, earth, sun, ccor_map, valid_satellites)
+
+        # Identify Target Satellites within the FOV:
+        candidates = get_satellites_in_fov(
+            tlabels,
+            obs_satellite_data.all_ccor_coords,
+            obs_satellite_data.all_sun_coords,
+            obs_satellite_data.all_sat_coords,
+            obs_satellite_data.all_sat_names,
+            obs_satellite_data.all_sat_pos,
+            fov_angle=fov_angle,
+            radius_search=search_radius,
+        )  # noqa: F841

--- a/object_identification/sat_id.py
+++ b/object_identification/sat_id.py
@@ -120,11 +120,15 @@ def run_satellite_id(
             radius_search=search_radius,
         )  # noqa: F841
 
-        sat_dict = {}.fromkeys(["satellite_name", "satellite_angle", "satellite_pos", "satellite_distance"])
+        sat_dict = {}
+        sat_dict["date_obs"] = obs_time.isot
+        sat_dict["date_avg"] = avg_time.isot
+        sat_dict["date_end"] = end_time.isot
+        sat_dict["parent_filename"] = os.path.basename(f)
         sat_dict["satellite_name"] = candidates.get_sat_id
-        sat_dict["satellite_angle"] = candidates.get_angle_in_fov
-        sat_dict["satellite_position"] = candidates.get_angle_locs
-        sat_dict["satellite_distance"] = candidates.get_dist
+        sat_dict["satellite_angle"] = candidates.get_angle_in_fov  # degrees
+        sat_dict["satellite_position"] = candidates.get_angle_locs  # degrees (angular positions from boresight)
+        sat_dict["satellite_distance"] = candidates.get_dist  # km
 
         if write_output_files:
             write_sat_output(header["DATE-OBS"], header["DATE-END"], sat_dict)

--- a/object_identification/sat_id.py
+++ b/object_identification/sat_id.py
@@ -7,7 +7,7 @@ from astropy.time import Time
 
 
 from .utils.retrieve_data import load_planetary_data
-from .utils.io import read_input
+from .utils.io import read_input, write_sat_output
 from .sat_utils.find_satellites import get_all_positions_for_times, get_satellites_in_fov
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
@@ -43,7 +43,11 @@ def remove_duplicate_sat_entries(satellite_list: list[Any]) -> list[Any]:
 
 
 def run_satellite_id(
-    inputs: list[Any], tle: str, search_radius: int | float = 30e3, fov_angle: int | float = 11
+    inputs: list[Any],
+    tle: str,
+    search_radius: int | float = 30e3,
+    fov_angle: int | float = 11,
+    write_output_files: bool = True,
 ) -> None:
     """
     Retrieve candidate satellites, and their approximate pixel locations, within
@@ -115,3 +119,12 @@ def run_satellite_id(
             fov_angle=fov_angle,
             radius_search=search_radius,
         )  # noqa: F841
+
+        sat_dict = {}.fromkeys(["satellite_name", "satellite_angle", "satellite_pos", "satellite_distance"])
+        sat_dict["satellite_name"] = candidates.get_sat_id
+        sat_dict["satellite_angle"] = candidates.get_angle_in_fov
+        sat_dict["satellite_position"] = candidates.get_angle_locs
+        sat_dict["satellite_distance"] = candidates.get_dist
+
+        if write_output_files:
+            write_sat_output(header["DATE-OBS"], header["DATE-END"], sat_dict)

--- a/object_identification/sat_utils/find_satellites.py
+++ b/object_identification/sat_utils/find_satellites.py
@@ -32,13 +32,13 @@ class GetAllSatellites:
 
 @dataclass(frozen=True, kw_only=True)
 class GetCandidateSatellites:
-    get_angle_in_fov: npt.NDArray[Any]  # satellite-sun angle (similar to sun-earth, and/or sun-moon)
-    get_dist: npt.NDArray[Any]  # distance from satellite to observer
-    get_sat_id: npt.NDArray[Any]  # satellite ids within FOV
-    get_tlabel: npt.NDArray[Any]  # time labels for mapping values/locations to corresponding time stamp
-    get_angle_locs: npt.NDArray[Any]  # approximation to 2D locations of satellite in FOV/image
+    get_angle_in_fov: list[Any]  # satellite-sun angle (similar to sun-earth, and/or sun-moon)
+    get_dist: list[Any]  # distance from satellite to observer
+    get_sat_id: list[Any]  # satellite ids within FOV
+    get_tlabel: list[Any]  # time labels for mapping values/locations to corresponding time stamp
+    get_angle_locs: list[Any]  # approximation to 2D locations of satellite in FOV/image
     get_sat_collection: list[Any]  # satellite vector function objects for valid satellites
-    get_sat_pos: npt.NDArray[Any]  # satellite vector positions for reference
+    get_sat_pos: list[Any]  # satellite vector positions for reference
 
 
 ##########################################################################
@@ -250,12 +250,12 @@ def get_satellites_in_fov(
        - get_sat_collation = get satellites locations within the search radius
     """
     # Initialize arrays of type object to store lists of varying sizes
-    get_angle_in_fov = np.zeros([len(tlabels)], dtype="object")
-    get_dist = np.zeros([len(tlabels)], dtype="object")
-    get_sat_id = np.zeros([len(tlabels)], dtype="object")
-    get_tlabel = np.zeros([len(tlabels)], dtype="object")
-    get_angle_locs = np.zeros([len(tlabels)], dtype="object")
-    get_sat_pos = np.zeros([len(tlabels)], dtype="object")
+    get_angle_in_fov = []  # np.zeros([len(tlabels)], dtype="object")
+    get_dist = []  # np.zeros([len(tlabels)], dtype="object")
+    get_sat_id = []  # np.zeros([len(tlabels)], dtype="object")
+    get_tlabel = []  # np.zeros([len(tlabels)], dtype="object")
+    get_angle_locs = []  # np.zeros([len(tlabels)], dtype="object")
+    get_sat_pos = []  # np.zeros([len(tlabels)], dtype="object")
     get_sat_collection = []
 
     # Iterate over all 3 timestamps in CCOR file:
@@ -341,13 +341,13 @@ def get_satellites_in_fov(
                         )
 
         # Store in lists
-        get_angle_in_fov[tidx] = valid_angles
-        get_dist[tidx] = valid_dists
-        get_sat_id[tidx] = valid_ids
-        get_tlabel[tidx] = valid_tlabel
-        get_angle_locs[tidx] = valid_angle_locs
+        get_angle_in_fov.append(valid_angles)
+        get_dist.append(valid_dists)
+        get_sat_id.append(valid_ids)
+        get_tlabel.append(valid_tlabel)
+        get_angle_locs.append(valid_angle_locs)
         get_sat_collection.append(get_close_points)
-        get_sat_pos[tidx] = valid_sat_pos
+        get_sat_pos.append(valid_sat_pos)
 
     return GetCandidateSatellites(
         get_angle_in_fov=get_angle_in_fov,

--- a/object_identification/sat_utils/find_satellites.py
+++ b/object_identification/sat_utils/find_satellites.py
@@ -1,19 +1,58 @@
+import os
+import logging
+from dataclasses import dataclass
+from typing import Any
+import numpy.typing as npt
+from skyfield.vectorlib import VectorFunction
+from sunpy.map.mapbase import GenericMap
+
 import numpy as np
 from astropy.coordinates import SkyCoord, CartesianRepresentation
 import astropy.units as u
-from astropy.coordinates import TEME, CartesianDifferential, ITRS  # noqa: F401
-from sunpy.coordinates import frames  # noqa: F401
 
-from position_transformations import (
-    get_angle,
-    get_angular_positions,
-)
+from . import position_transformations
+
+get_angle = position_transformations.get_angle
+get_angular_positions = position_transformations.get_angular_positions
+
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class GetAllSatellites:
+    all_sat_names: npt.NDArray[Any]  # catalogue sattelite names in TLE
+    all_sat_coords: npt.NDArray[Any]  # coordinates/positions of satellites
+    all_sun_coords: npt.NDArray[Any]  # sun coordinates at obstime
+    all_ccor_coords: npt.NDArray[Any]  # ccor coordinates at obstime
+    all_earth_coords: npt.NDArray[Any]  # earth coordinates at obstime
+    all_sat_pos: npt.NDArray[Any]  # satellite positions (VectorFunction) objects
+    goes_sat_coords: npt.NDArray[Any]  # GOES-19 satellite coords
+
+
+@dataclass(frozen=True, kw_only=True)
+class GetCandidateSatellites:
+    get_angle_in_fov: npt.NDArray[Any]  # satellite-sun angle (similar to sun-earth, and/or sun-moon)
+    get_dist: npt.NDArray[Any]  # distance from satellite to observer
+    get_sat_id: npt.NDArray[Any]  # satellite ids within FOV
+    get_tlabel: npt.NDArray[Any]  # time labels for mapping values/locations to corresponding time stamp
+    get_angle_locs: npt.NDArray[Any]  # approximation to 2D locations of satellite in FOV/image
+    get_sat_collection: list[Any]  # satellite vector function objects for valid satellites
+    get_sat_pos: npt.NDArray[Any]  # satellite vector positions for reference
 
 
 ##########################################################################
 # We Want the Positions for All possible Times During the Image Capture: #
 ##########################################################################
-def get_all_positions_for_times(astro_times, j_times, earth, sun, ccor_map, valid_sat, use_gcrs=False):
+def get_all_positions_for_times(
+    astro_times: list[Any],
+    j_times: list[Any],
+    earth: VectorFunction,
+    sun: VectorFunction,
+    ccor_map: GenericMap,
+    valid_sat: list[Any],
+    use_gcrs: bool = False,
+) -> GetAllSatellites:
     """
     Get the Sun, CCOR, Earth, and satellite positions for
     all times reported in a CCOR data product file's header.
@@ -59,6 +98,7 @@ def get_all_positions_for_times(astro_times, j_times, earth, sun, ccor_map, vali
 
     # Iterate over the file times:
     for at, t in zip(astro_times, j_times):
+        logger.info(f"Getting satellite data for time: {at.isot}")
 
         # Get Earth and Sun Locations at Observation Time
         # ---------------------------------------------
@@ -159,7 +199,7 @@ def get_all_positions_for_times(astro_times, j_times, earth, sun, ccor_map, vali
         az = np.arctan2((ccor_y - suny), (ccor_x - sunx))  # 180 - az in degrees if plotting grid
         el = np.arccos((ccor_z - sunz) / pos)  # also needs to be adjusted if plotting  # noqa: F841
         sc_angle = np.rad2deg(np.arccos((sunz - ccor_z) / pos))  # angle to sun's position
-        print(
+        logger.info(
             f"Sun is at an inclination angle of {sc_angle} from "
             + f"x-axis at time {t.utc_datetime()} and {az} from horizontal."
         )
@@ -171,39 +211,30 @@ def get_all_positions_for_times(astro_times, j_times, earth, sun, ccor_map, vali
         all_earth_coords.append((earx, eary, earz))
         all_sat_pos.append(sat_pos)
 
-    # Prep the coordinate arrays for finding the closest positions by making them into arrays.
-    # For each Fits file all time stamps will be checked, so 3xN_satellites
-    all_sat_names = np.array(all_sat_names)
-    all_sat_coords = np.array(all_sat_coords)
-    all_sun_coords = np.array(all_sun_coords)
-    all_ccor_coords = np.array(all_ccor_coords)
-    all_earth_coords = np.array(all_earth_coords)
-    all_sat_pos = np.array(all_sat_pos)
-
     # Find goes position:
-    goes_sat_coord = all_sat_coords[np.where(all_sat_names == "GOES 19")]
+    goes_sat_coord = np.array(all_sat_coords)[np.where(np.array(all_sat_names) == "GOES 19")]
 
-    return (
-        all_sat_names,
-        all_sat_coords,
-        all_sun_coords,
-        all_ccor_coords,
-        all_earth_coords,
-        all_sat_pos,
-        goes_sat_coord,
+    return GetAllSatellites(
+        all_sat_names=np.array(all_sat_names),
+        all_sat_coords=np.array(all_sat_coords),
+        all_sun_coords=np.array(all_sun_coords),
+        all_ccor_coords=np.array(all_ccor_coords),
+        all_earth_coords=np.array(all_earth_coords),
+        all_sat_pos=np.array(all_sat_pos),
+        goes_sat_coords=np.array(goes_sat_coord),
     )
 
 
 def get_satellites_in_fov(
-    tlabels,
-    all_ccor_coords,
-    all_sun_coords,
-    all_sat_coords,
-    all_sat_names,
-    all_sat_pos,
-    fov_angle=11,
-    radius_search=30e3,
-):
+    tlabels: list[Any],
+    all_ccor_coords: npt.NDArray[Any],
+    all_sun_coords: npt.NDArray[Any],
+    all_sat_coords: npt.NDArray[Any],
+    all_sat_names: npt.NDArray[Any],
+    all_sat_pos: npt.NDArray[Any],
+    fov_angle: int | float = 11,
+    radius_search: int | float = 30e3,
+) -> GetCandidateSatellites:
     """
     Identify all satellites in the CCOR FOV within 11 degrees of the boresight and
     retrieve their cartesian locations, angular positions from the boresight, distances from
@@ -220,7 +251,6 @@ def get_satellites_in_fov(
     """
     # Initialize arrays of type object to store lists of varying sizes
     get_angle_in_fov = np.zeros([len(tlabels)], dtype="object")
-    # get_pix_locs = np.zeros([len(tlabels)], dtype='object')
     get_dist = np.zeros([len(tlabels)], dtype="object")
     get_sat_id = np.zeros([len(tlabels)], dtype="object")
     get_tlabel = np.zeros([len(tlabels)], dtype="object")
@@ -234,7 +264,6 @@ def get_satellites_in_fov(
         get_close_points = []
         get_close_ids = []
         valid_angles = []
-        valid_locs = []  # noqa: F841
         valid_ids = []
         valid_tlabel = []
         valid_dists = []
@@ -286,14 +315,6 @@ def get_satellites_in_fov(
                         np.array([xrel, yrel, zrel]), np.array([ccor_x, ccor_y, ccor_z]), np.array([sunx, suny, sunz])
                     )
 
-                    # Get approximate Pixel locations: [no fully tested]
-                    # locs = get_ortho_angle(
-                    #     np.array([xrel, yrel, zrel]),
-                    #     np.array([ccor_x, ccor_y, ccor_z]),
-                    #     np.array([sunx, suny, sunz]),
-                    #     header['YAWFLIP']
-                    # )
-
                     angular_locs = get_angular_positions(
                         np.array([xrel, yrel, zrel]),
                         np.array([ccor_x, ccor_y, ccor_z]),
@@ -314,14 +335,13 @@ def get_satellites_in_fov(
                         valid_tlabel.append(tlabels[tidx])
                         valid_angle_locs.append(angular_locs)
                         valid_sat_pos.append(sat_pos)
-                        print(
+                        logger.info(
                             f"{id} has a SAT_ANGLE of {sat_angle} from the boresight | Angular Locations (x, y):"
                             + f" {angular_locs} | Distance from CCOR is {spos} km."
                         )
 
         # Store in lists
         get_angle_in_fov[tidx] = valid_angles
-        # get_pix_locs[tidx] = (valid_locs)
         get_dist[tidx] = valid_dists
         get_sat_id[tidx] = valid_ids
         get_tlabel[tidx] = valid_tlabel
@@ -329,7 +349,15 @@ def get_satellites_in_fov(
         get_sat_collection.append(get_close_points)
         get_sat_pos[tidx] = valid_sat_pos
 
-    return (get_angle_in_fov, get_dist, get_sat_id, get_tlabel, get_angle_locs, get_sat_collection, get_sat_pos)
+    return GetCandidateSatellites(
+        get_angle_in_fov=get_angle_in_fov,
+        get_dist=get_dist,
+        get_sat_id=get_sat_id,
+        get_tlabel=get_tlabel,
+        get_angle_locs=get_angle_locs,
+        get_sat_collection=get_sat_collection,
+        get_sat_pos=get_sat_pos,
+    )
 
 
 def create_cone_mask(shape, center, radius, height, angle, direction, grid):

--- a/object_identification/sat_utils/find_satellites.py
+++ b/object_identification/sat_utils/find_satellites.py
@@ -333,7 +333,7 @@ def get_satellites_in_fov(
                         valid_ids.append(id)
                         valid_dists.append(spos)
                         valid_tlabel.append(tlabels[tidx])
-                        valid_angle_locs.append(angular_locs)
+                        valid_angle_locs.append((angular_locs[0].tolist(), angular_locs[1].tolist()))
                         valid_sat_pos.append(sat_pos)
                         logger.info(
                             f"{id} has a SAT_ANGLE of {sat_angle} from the boresight | Angular Locations (x, y):"

--- a/object_identification/utils/io.py
+++ b/object_identification/utils/io.py
@@ -68,6 +68,34 @@ def write_output(obs_time: str, end_time: str, data_dict: dict[str, Any]) -> Non
         raise CCORExitError("No data to output...skipping file")
 
 
+def write_sat_output(obs_time: str, end_time: str, sat_dict: dict[str, Any]) -> None:
+    """
+    Essentially a duplicate of above, but with the expectation that how we store these data
+    will change.
+    """
+
+    obs_time_fmt = obs_time.replace("-", "").replace(":", "").split(".")[0]
+    end_time_fmt = end_time.replace("-", "").replace(":", "").split(".")[0]
+    file_tstamp = f"s{obs_time_fmt}Z_e{end_time_fmt}Z"
+    out_dir = f"{obs_time_fmt.split('T')[0]}_satellites"
+    creation = datetime.datetime.now().strftime("p%Y%m%dT%H%M%SZ")
+
+    # Create output directory if it does  not exist:
+    try:
+        os.makedirs(os.path.join(ROOT_DIR.parent, f"outputs/{out_dir}"), exist_ok=True)
+    except OSError:
+        logger.exception("Error creating data directory.")
+
+    try:
+        with open(
+            os.path.join(ROOT_DIR.parent, f"outputs/{out_dir}/sci_ccor1-sat_g19_{file_tstamp}_{creation}_pub.json"),
+            "w",
+        ) as data_file:
+            json.dump(sat_dict, data_file, indent=4)
+    except TypeError:
+        raise CCORExitError("No data to output...skipping file")
+
+
 def get_vignetting_func() -> npt.NDArray[Any]:
     """
     Retrieve the vignetting function for plotting.


### PR DESCRIPTION
Summary:
------
This PR adds the algorithm code to do the satellite identification for any dataset. The following input params are added to `cli` for running the satellite identification: 

 `--tle`: The two-line element (TLE) data file that *corresponds* to the date for which artifacts are being searched for.
 `--search_radius`: The user specified search radius for searching for candidate satellites surrounding the instrument from which these images are captured. 
 `--fov_angle`: The instrument's field-of-view (FOV), or angle spanning the complete visible part of the image.

Note: this algorithm requires that a user is able to find archived TLE data for retrospectively processing data. This requires an account with `[space-track](https://www.space-track.org/auth/login)`. From there, any TLE file for any particular date may be pulled. If using current image data, one may retrieve TLE data from `[CelesTrak](https://celestrak.org/NORAD/elements/)`.

The satellite identification code is kept separate from the rest of the object identification code since it's still not complete, or thoroughly tested.

Data are written to JSON files (for now) with the following data contained for each input file being processed: 
 - date-obs: observation time of input file image capture
 - date-avg: averaged time of input file (between start and end of image capture)
 - date-end: end time of input file image capture
 - parent_filename: name of file/image being processed for reference 
 - satellite_name*: list of satellite names 
 - satellite_angle*: angle of satellite from instrument boresight
 - satellite_position*: approximate position of satellite in image (angles from boresight)
 - satellite_distance*: distance from satellite to instrument

* The data are contained in lists, and have the following structure: 
```python
"satellite_angle": [
        [
            4.699849399874481,
            2.0514590326211795,
            3.7827543602413445
        ],
        [
            2.5895520819298024,
            2.2533976109580083,
            4.131329070242079
        ],
        [
            2.258076233552221,
            2.43752704275366,
            4.403874392967937
        ]
    ],
```
There are 3 lists embedded into the variable list each representing the 3 time stamps (date-obs, date-avg, and date-end) in that order.